### PR TITLE
Allow minor/patch dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
   ],
   "dependencies": {
     "http-errors": "^2.0.0",
-    "safe-buffer": "5.2.1",
-    "uid-safe": "2.1.5"
+    "safe-buffer": "^5.2.1",
+    "uid-safe": "^2.1.5"
   },
   "devDependencies": {
     "eslint": "^8.5.0",
-    "eslint-plugin-markdown": "2.2.1",
+    "eslint-plugin-markdown": "^2.2.1",
     "mkdirp": "^1.0.4",
     "mocha": "^9.1.3",
-    "nyc": "15.1.0",
-    "pend": "1.2.0",
-    "require-all": "3.0.0",
+    "nyc": "^15.1.0",
+    "pend": "^1.2.0",
+    "require-all": "^3.0.0",
     "rimraf": "^3.0.2",
     "superagent": "^6.1.0"
   },


### PR DESCRIPTION
This just helps with dependency version flexibility, it shouldn't cause any breaking changes as long as the package maintainers use minor/patch semvers correctly.